### PR TITLE
explain what 'full cluster view' means for coordinator node dashboard

### DIFF
--- a/docs/latest/Coordinator.md
+++ b/docs/latest/Coordinator.md
@@ -117,7 +117,7 @@ The Druid coordinator exposes a web GUI for displaying cluster information and r
 http://<COORDINATOR_IP>:<COORDINATOR_PORT>
 ```
 
- There exists a full cluster view, as well as views for individual historical nodes, datasources and segments themselves. Segment information can be displayed in raw JSON form or as part of a sortable and filterable table.
+ There exists a full cluster view (which shows only the realtime and historical nodes), as well as views for individual historical nodes, datasources and segments themselves. Segment information can be displayed in raw JSON form or as part of a sortable and filterable table.
 
 The coordinator console also exposes an interface to creating and editing rules. All valid datasources configured in the segment database, along with a default datasource, are available for configuration. Rules of different types can be added, deleted or edited.
 


### PR DESCRIPTION
the 'full cluster view' term is confusing since one expects to see other nodes like broker node, etc there too. this PR clarifies that
