### PR TITLE
Move "libraries" page out of docs and onto main site.

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ id: home
         <p>
           Visualize data with <a href="https://github.com/implydata/pivot">Pivot</a> and <a
           href="https://github.com/airbnb/caravel">Caravel</a>.
-          Query data in <a href="/docs/{{site.druid_version}}//development/libraries.html">many different languages</a>.
+          Query data in <a href="/libraries.html">many different languages</a>.
         </p>
 
       </div>

--- a/libraries.md
+++ b/libraries.md
@@ -1,0 +1,69 @@
+---
+title: Community and Third Party Software
+layout: simple_page
+---
+
+Query Libraries
+---------------
+
+Some great folks have written their own libraries to interact with Druid.
+
+#### Python
+
+* [druid-io/pydruid](https://github.com/druid-io/pydruid) - A python client for Druid
+
+#### R
+
+* [druid-io/RDruid](https://github.com/druid-io/RDruid) - An R connector for Druid
+
+#### JavaScript
+
+* [implydata/plywood](https://github.com/implydata/plywood) - A higher level API for Druid. An extension of the work that was started in facet.js.
+* [7eggs/node-druid-query](https://github.com/7eggs/node-druid-query) - A Node.js client for Druid
+
+#### Clojure
+
+* [y42/clj-druid](https://github.com/y42/clj-druid) - A Clojure client for Druid
+
+#### Ruby
+
+* [ruby-druid/ruby-druid](https://github.com/ruby-druid/ruby-druid) - A ruby client for Druid
+* [redBorder/druid_config](https://github.com/redBorder/druid_config) - A ruby client to configure and check the status of a Druid Cluster
+
+#### SQL
+
+* [implydata/plyql](https://github.com/implydata/plyql) - A command line and HTTP interface for issuing SQL queries to Druid
+
+Other Druid Distributions
+-------------------------
+
+* [Imply Analytics Platform](http://imply.io/download) - The Imply Analytics platform includes Druid bundled with all its dependencies, an exploratory analytics UI, and a SQL layer.
+* [eBay/embedded-druid](https://github.com/eBay/embedded-druid) - Leveraging Druid capabilities in stand alone application
+
+UIs
+---
+
+* [airbnb/caravel](https://github.com/airbnb/caravel) - A web application to slice, dice and visualize data out of Druid. Formerly Panoramix
+* [grafana](https://github.com/Quantiply/grafana-plugins/tree/master/features/druid) - A plugin for [Grafana](http://grafana.org/)
+* [Pivot](https://github.com/implydata/pivot) - An exploratory analytics UI for Druid
+* [Metabase](https://github.com/metabase/metabase) - Simple dashboards, charts and query tool for your Druid DB
+
+Tools
+-----
+
+* [Insert Segments](/docs/latest/operations/insert-segment-to-db.html) - A tool that can insert segments' metadata into Druid metadata storage.
+* [liquidm/druid-dumbo](https://github.com/liquidm/druid-dumbo) - Scripts to help generate batch configs for the ingestion of data into Druid
+* [housejester/druid-test-harness](https://github.com/housejester/druid-test-harness) - A set of scripts to simplify standing up some servers and seeing how things work
+
+Community Extensions
+--------------------
+
+These are extensions from the community, beyond those included in the Druid repository itself.
+
+* [acesinc/druid-cors-filter-extension](https://github.com/acesinc/druid-cors-filter-extension) - An extension to enable CORS headers in http requests.
+
+Add Your Software
+-----------------
+
+If you've written software that uses Druid and want it included on this page,
+[edit it on GitHub](https://github.com/druid-io/druid-io.github.io/blob/master/libraries.md) to create a pull request!


### PR DESCRIPTION
Easier to keep up to date than tying it to a Druid release.