### PR TITLE
removes legacy company

### DIFF
--- a/druid-powered.md
+++ b/druid-powered.md
@@ -414,14 +414,6 @@ Youku Tudou employs Druid for real-time advertising analysis of huge volumes of 
 
 China Youzan is a SaaS company which principally engaged in retail science and technology. We use Druid for business intelligence (BI) analytics and application performance management (APM) metrics
 
-## ZeroX
-
-[ZeroX](https://zero-x.co/) is a data analytics company that provides cloud hosted and privately managed Druid clusters.
-
-* [Shaman: A Druid Manager for the Cloud](https://shaman-ui.zero-x.co/#/docs/getting-started)
-* [Interactive Bid Requests w/ Apache Druid](https://blog.zero-x.co/2017/06/05/interactive-bid-requests-apache-druid.html)
-* [Programmatic Conversion Funnels w/ Apache Druid](https://blog.zero-x.co/2017/06/09/programmatic-conversion-funnels-apache-druid.html)
-
 ## Zhihu
 
 [Zhihu](https://www.zhihu.com/) is a Chinese question-and-answer website. In Zhihu, Druid is used to power clients' interactive queries, data reports, A/B testing and performance monitoring. Almost 1T per day data is ingested into druid cluster, and we are strongly depending on thetaSketch aggregator for computing cardinality and retention, looking forward to more improvement on DataSketch.


### PR DESCRIPTION
This PR removes the legacy ZeroX company, we no longer provide hosted Druid services. Everyone should use Imply for that!