### PR TITLE
add break-word to fix table overflow

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -110,6 +110,8 @@ html, body {
       font-weight: 700; }
     html table th, html table td, body table th, body table td {
       padding: 5px; }
+      html table th:nth-child(1), html table th:nth-child(2), html table td:nth-child(1), html table td:nth-child(2), body table th:nth-child(1), body table th:nth-child(2), body table td:nth-child(1), body table td:nth-child(2) {
+        word-break: break-word; }
   html blockquote, body blockquote {
     font-size: 14px;
     font-style: italic;

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -111,6 +111,10 @@ html, body {
 
     th, td {
       padding: 5px;
+
+      &:nth-child(1), &:nth-child(2) {
+        word-break: break-word;
+      }
     }
   }
 


### PR DESCRIPTION
Added `word-break: break-word;` to the first and second column of a table this prevents the long uninterrupted strings keys in the first and second columns to expand the table beyond its container.

Before:
![image](https://user-images.githubusercontent.com/177816/48990175-3fe44600-f0e2-11e8-9406-a09d7dd7728f.png)

After:
![image](https://user-images.githubusercontent.com/177816/48990188-4f638f00-f0e2-11e8-9bca-bda2df3b03d6.png)

Ideally instead of writing `druid.auth.authenticator.kerberos.serverPrincipal` in every doc key we would write `*.serverPrincipal` but this update needs to go into the main druid repo where the docs live.
