### PR TITLE
Re-unite downloads page

### DIFF
--- a/_includes/page_footer.html
+++ b/_includes/page_footer.html
@@ -8,7 +8,7 @@
     <a href="/druid-powered">Powered by Druid</a>&ensp;·&ensp;
     <a href="/docs/latest">Docs</a>&ensp;·&ensp;
     <a href="/community/">Community</a>&ensp;·&ensp;
-    <a href="/downloads">Download</a>&ensp;·&ensp;
+    <a href="/downloads.html">Download</a>&ensp;·&ensp;
     <a href="/faq">FAQ</a>
     </p>
   </div>

--- a/_includes/page_header.html
+++ b/_includes/page_header.html
@@ -13,7 +13,7 @@
         <li class="{% if page.sectionid == 'powered-by' %} active{% endif %}"><a href="/druid-powered">Powered By</a></li>
         <li class="{% if page.sectionid == 'docs' %} active{% endif %}"><a href="/docs/latest/design/">Docs</a></li>
         <li class="{% if page.sectionid == 'community' %} active{% endif %}"><a href="/community/">Community</a></li>
-        <li class="{% if page.sectionid == 'download' %} active{% endif %} button-link"><a href="/downloads">Download</a></li>
+        <li class="{% if page.sectionid == 'download' %} active{% endif %} button-link"><a href="/downloads.html">Download</a></li>
       </ul>
     </div>
   </div>

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -1,0 +1,6 @@
+---
+title: Download
+layout: redirect_page
+redirect_target: /downloads.html
+---
+

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ id: home
   <div class="row">
     <div class="text-center">
     <p class="lead">Apache Druid (incubating) is a high performance analytics data store for event-driven data.</p>
-    <p><a class="button" href="/downloads"><span class="fa fa-download"></span> Download</a>
+    <p><a class="button" href="/downloads.html"><span class="fa fa-download"></span> Download</a>
     <a class="button" href="https://github.com/apache/incubator-druid/"><span class="fab fa-github"></span> GitHub</a></p>
   </div>
   </div>


### PR DESCRIPTION
In the recent webpage redesign the links to the `/downloads.html` page were changed to `/downloads`.
Due to how GH pages work both pages exist. We believe that by introducing links to the `/downloads` page we have split the 'ranking' score of this page in different search engines. This made each page rank lower in the search results and as a result less traffic was directed to this page.

This PR aims to fix and reverse that change by:

1. making the links in the site point to the .html version of the page
2. hijacking the `/downloads` route (with the aid of a `/downloads/index.md` file) to redirect to the canonical `/downloads.html` route.

Hopefully this will restore the `/downloads.html` route to its former glory in the eyes of the search engine gods.