### PR TITLE
download should work even when there is adblock

### DIFF
--- a/_includes/page_footer.html
+++ b/_includes/page_footer.html
@@ -36,11 +36,7 @@
 </script>
 <script>
   function trackDownload(type, url) {
-    ga('send', 'event', 'download', type, url, {'hitCallback':
-        function () {
-          document.location = url;
-        }
-    });
+    ga('send', 'event', 'download', type, url);
   }
 </script>
 <script src="//code.jquery.com/jquery.min.js"></script>

--- a/downloads.md
+++ b/downloads.md
@@ -10,7 +10,7 @@ canonical: 'http://druid.io/downloads.html'
 The current Druid stable release is {{ site.druid_stable_version }}. This version is recommended for production use.
 
 <p>
-<a class="large-button download" href="http://static.druid.io/artifacts/releases/druid-{{ site.druid_stable_version }}-bin.tar.gz" onclick="trackDownload('button', 'http://static.druid.io/artifacts/releases/druid-{{ site.druid_stable_version }}-bin.tar.gz');return false;"><span class="fa fa-download"></span> Download {{site.druid_stable_version}} release</a><br>
+<a class="large-button download" href="http://static.druid.io/artifacts/releases/druid-{{ site.druid_stable_version }}-bin.tar.gz" download onclick="trackDownload('button', 'http://static.druid.io/artifacts/releases/druid-{{ site.druid_stable_version }}-bin.tar.gz');"><span class="fa fa-download"></span> Download {{site.druid_stable_version}} release</a><br>
 </p>
 
 {% if site.druid_rc_version != site.druid_stable_version %}
@@ -18,7 +18,7 @@ The current Druid stable release is {{ site.druid_stable_version }}. This versio
 
 The current Druid release candidate is {{ site.druid_rc_version }}.
 <p>
-<a class="large-button download" href="http://static.druid.io/artifacts/releases/druid-{{ site.druid_rc_version }}-bin.tar.gz" onclick="trackDownload('button', 'http://static.druid.io/artifacts/releases/druid-{{ site.druid_rc_version }}-bin.tar.gz');return false;"><span class="fa fa-download"></span> Download {{site.druid_rc_version}} release candidate</a><br>
+<a class="large-button download" href="http://static.druid.io/artifacts/releases/druid-{{ site.druid_rc_version }}-bin.tar.gz" download onclick="trackDownload('button', 'http://static.druid.io/artifacts/releases/druid-{{ site.druid_rc_version }}-bin.tar.gz');"><span class="fa fa-download"></span> Download {{site.druid_rc_version}} release candidate</a><br>
 </p>
 
 {% else %}


### PR DESCRIPTION
The way the current download tracking is configured relies on the google analytics `hitCallback` fn being called (since the `onclick` returns `false` which cancels the default action).

This means that if someone comes to the site and can not load `//www.google-analytics.com/analytics.js` because of an adblock extension (or something at a DNS level like a [Pi-hole](https://pi-hole.net/) ) they effectively can not download Druid from the webpage.

Note: if you are trying to repro this yourself be aware that some more sophisticated adblockers like [uBlock Origin](https://github.com/gorhill/uBlock) do not simply block the `//www.google-analytics.com/analytics.js` resource but actually substitute it with a script like this:

```
function() {
		var len = arguments.length;
		if ( len === 0 ) {
			return;
		}
		var f = arguments[len-1];
		if ( typeof f !== 'object' || f === null || typeof f.hitCallback !== 'function' ) {
			return;
		}
		try {
			f.hitCallback();
		} catch (ex) {
		}
	}
```

in their attempts to not break pages like http://druid.io/downloads.html

Also added the html5 download attribute :-)