### PR TITLE
Try HTTPS CDN for Font Awesome.

### DIFF
--- a/_includes/site_head.html
+++ b/_includes/site_head.html
@@ -9,7 +9,7 @@
 <link rel="alternate" type="application/atom+xml" href="/feed">
 <link rel="shortcut icon" href="/img/favicon.png">
 
-<link rel="stylesheet" href="//use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
 
 <link href='//fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700,300italic|Open+Sans:300italic,400italic,600italic,400,300,600,700' rel='stylesheet' type='text/css'>
 


### PR DESCRIPTION
I'm seeing errors on Safari:

> Failed to load resource: Cross-origin redirection to https://use.fontawesome.com/releases/v5.7.2/css/all.css denied by Cross-Origin Resource Sharing policy: Origin http://druid.io is not allowed by Access-Control-Allow-Origin.

And Chrome:

> Access to CSS stylesheet at 'http://use.fontawesome.com/releases/v5.7.2/css/all.css' from origin 'http://druid.io' has been blocked by CORS policy: The response is invalid.

The CORS headers on the CDN look fine to me, but I thought it was suspicious that the Safari error mentioned https (it should have been using http since druid.io is http). I switched the URL from protocol-relative to https to see if this will do anything.