### PR TITLE
Move /use-cases to druid.apache.org

### DIFF
--- a/_includes/page_footer.html
+++ b/_includes/page_footer.html
@@ -4,7 +4,7 @@
   <div class="text-center">
     <p>
     <a href="/technology">Technology</a>&ensp;·&ensp;
-    <a href="/use-cases">Use Cases</a>&ensp;·&ensp;
+    <a href="https://druid.apache.org/use-cases">Use Cases</a>&ensp;·&ensp;
     <a href="/druid-powered">Powered by Druid</a>&ensp;·&ensp;
     <a href="/docs/latest">Docs</a>&ensp;·&ensp;
     <a href="https://druid.apache.org/community/">Community</a>&ensp;·&ensp;

--- a/_includes/page_header.html
+++ b/_includes/page_header.html
@@ -9,7 +9,7 @@
     <div class="right-cont">
       <ul class="links">
         <li class="{% if page.sectionid == 'technology' %} active{% endif %}"><a href="/technology">Technology</a></li>
-        <li class="{% if page.sectionid == 'use-cases' %} active{% endif %}"><a href="/use-cases">Use Cases</a></li>
+        <li class="{% if page.sectionid == 'use-cases' %} active{% endif %}"><a href="https://druid.apache.org/use-cases">Use Cases</a></li>
         <li class="{% if page.sectionid == 'powered-by' %} active{% endif %}"><a href="/druid-powered">Powered By</a></li>
         <li class="{% if page.sectionid == 'docs' %} active{% endif %}"><a href="/docs/latest/design/">Docs</a></li>
         <li class="{% if page.sectionid == 'community' %} active{% endif %}"><a href="https://druid.apache.org/community/">Community</a></li>


### PR DESCRIPTION
It's being served here: https://druid.apache.org/use-cases.

This updates the header/footer links on druid.io.